### PR TITLE
Preserve hobby ordering in user profiles

### DIFF
--- a/spring-webapi/src/main/java/com/example/demo/user/domain/UserProfile.java
+++ b/spring-webapi/src/main/java/com/example/demo/user/domain/UserProfile.java
@@ -10,15 +10,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -73,7 +76,8 @@ public class UserProfile {
     @ElementCollection
     @CollectionTable(name = "user_hobbies", joinColumns = @JoinColumn(name = "user_id"))
     @Column(name = "hobby", length = 64, nullable = false)
-    private Set<String> hobbies = new LinkedHashSet<>();
+    @OrderColumn(name = "hobby_order")
+    private List<String> hobbies = new ArrayList<>();
 
     @ManyToMany
     @JoinTable(
@@ -169,8 +173,8 @@ public class UserProfile {
         return updatedAt;
     }
 
-    public Set<String> getHobbies() {
-        return Collections.unmodifiableSet(hobbies);
+    public List<String> getHobbies() {
+        return Collections.unmodifiableList(hobbies);
     }
 
     public Set<UserProfile> getFriends() {
@@ -214,9 +218,11 @@ public class UserProfile {
         if (hobbies == null) {
             return;
         }
+        LinkedHashSet<String> uniqueHobbies = new LinkedHashSet<>();
         hobbies.stream()
                 .filter(Objects::nonNull)
-                .forEach(this.hobbies::add);
+                .forEach(uniqueHobbies::add);
+        this.hobbies.addAll(uniqueHobbies);
     }
 
     public void synchronizeFriends(Collection<UserProfile> desiredFriends) {


### PR DESCRIPTION
## Summary
- store user hobbies as an ordered list with an explicit order column so insertion order is preserved
- deduplicate hobbies while maintaining their encounter order when replacing the collection

## Testing
- mvn test *(fails: cannot download parent POM because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17b4cc1a8833286b26d8633448969