### PR TITLE
Improve auth secrets and chat pagination safety

### DIFF
--- a/spring-webapi/src/main/java/com/tribe/backend/TribeApplication.java
+++ b/spring-webapi/src/main/java/com/tribe/backend/TribeApplication.java
@@ -3,11 +3,9 @@ package com.tribe.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableAsync
 public class TribeApplication {
 
     public static void main(String[] args) {

--- a/spring-webapi/src/main/java/com/tribe/backend/chat/repository/ChatMessageRepository.java
+++ b/spring-webapi/src/main/java/com/tribe/backend/chat/repository/ChatMessageRepository.java
@@ -2,6 +2,7 @@ package com.tribe.backend.chat.repository;
 
 import com.tribe.backend.chat.domain.ChatMessage;
 import com.tribe.backend.chat.domain.ChatRoom;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -12,10 +13,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> {
 
-    @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom = :chatRoom AND (:cursor IS NULL OR m.id < :cursor) "
-        + "ORDER BY m.sentAt DESC")
+    @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom = :chatRoom AND "
+        + "(:sentAt IS NULL OR m.sentAt < :sentAt OR (m.sentAt = :sentAt AND m.id < :cursorId)) "
+        + "ORDER BY m.sentAt DESC, m.id DESC")
     List<ChatMessage> findRecentMessages(@Param("chatRoom") ChatRoom chatRoom,
-                                         @Param("cursor") UUID cursor,
+                                         @Param("sentAt") Instant sentAt,
+                                         @Param("cursorId") UUID cursorId,
                                          Pageable pageable);
 
     Optional<ChatMessage> findByChatRoomAndClientMessageId(ChatRoom chatRoom, String clientMessageId);

--- a/spring-webapi/src/main/java/com/tribe/backend/chat/web/ChatController.java
+++ b/spring-webapi/src/main/java/com/tribe/backend/chat/web/ChatController.java
@@ -8,6 +8,8 @@ import com.tribe.backend.chat.service.ChatService;
 import com.tribe.backend.common.dto.PageResponse;
 import com.tribe.backend.security.UserPrincipal;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
@@ -20,9 +22,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 
 @RestController
 @RequestMapping("/api/v1/chats")
+@Validated
 public class ChatController {
 
     private final ChatService chatService;
@@ -54,7 +58,8 @@ public class ChatController {
     @GetMapping("/{chatId}/messages")
     public PageResponse<ChatMessageResponse> history(@AuthenticationPrincipal UserPrincipal principal,
                                                      @PathVariable UUID chatId,
-                                                     @RequestParam(defaultValue = "50") int limit,
+                                                     @RequestParam(defaultValue = "50")
+                                                     @Min(1) @Max(100) int limit,
                                                      @RequestParam(required = false) UUID cursor) {
         return chatService.getRecentMessages(chatId, principal.getId(), limit, cursor);
     }

--- a/spring-webapi/src/main/java/com/tribe/backend/config/JwtProperties.java
+++ b/spring-webapi/src/main/java/com/tribe/backend/config/JwtProperties.java
@@ -1,15 +1,21 @@
 package com.tribe.backend.config;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 @Component
 @ConfigurationProperties(prefix = "app.security.jwt")
+@Validated
 public class JwtProperties {
 
     /**
      * Shared secret used for signing JWT access tokens.
      */
+    @NotBlank(message = "JWT signing secret must not be blank")
+    @Size(min = 32, message = "JWT signing secret must be at least 32 characters long")
     private String secret;
 
     /**

--- a/spring-webapi/src/main/java/com/tribe/backend/security/JwtAuthenticationFilter.java
+++ b/spring-webapi/src/main/java/com/tribe/backend/security/JwtAuthenticationFilter.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -18,6 +20,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
@@ -46,6 +50,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     }
                 }
             } catch (Exception ex) {
+                log.warn("Failed to parse JWT for request {} {} from {}", request.getMethod(), request.getRequestURI(),
+                    request.getRemoteAddr(), ex);
                 SecurityContextHolder.clearContext();
             }
         }

--- a/spring-webapi/src/main/java/com/tribe/backend/user/service/UserService.java
+++ b/spring-webapi/src/main/java/com/tribe/backend/user/service/UserService.java
@@ -23,6 +23,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class UserService {
 
+    private static final int MAX_RECOMMENDATIONS = 50;
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -96,11 +98,12 @@ public class UserService {
             candidates.addAll(userRepository.findBySharedInterests(userId, normalizedInterests));
         }
 
+        int cappedLimit = Math.min(limit, MAX_RECOMMENDATIONS);
         return candidates.stream()
             .distinct()
             .map(candidate -> toRecommendation(user, candidate))
             .sorted(Comparator.comparing(UserRecommendationResponse::compatibilityScore).reversed())
-            .limit(limit)
+            .limit(cappedLimit)
             .toList();
     }
 

--- a/spring-webapi/src/main/java/com/tribe/backend/user/web/UserController.java
+++ b/spring-webapi/src/main/java/com/tribe/backend/user/web/UserController.java
@@ -8,11 +8,14 @@ import com.tribe.backend.user.dto.UserUpdateRequest;
 import com.tribe.backend.user.service.UserService;
 import com.tribe.backend.security.UserPrincipal;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/users")
+@Validated
 public class UserController {
 
     private final UserService userService;
@@ -57,7 +61,8 @@ public class UserController {
     @GetMapping("/{userId}/recommendations")
     @PreAuthorize("#userId == principal.id")
     public PageResponse<UserRecommendationResponse> recommendations(@PathVariable UUID userId,
-                                                                    @RequestParam(defaultValue = "10") int limit,
+                                                                    @RequestParam(defaultValue = "10")
+                                                                    @Min(1) @Max(50) int limit,
                                                                     @AuthenticationPrincipal UserPrincipal principal) {
         List<UserRecommendationResponse> items = userService.getRecommendations(userId, limit);
         return new PageResponse<>(items, null, false);

--- a/spring-webapi/src/main/resources/application.yml
+++ b/spring-webapi/src/main/resources/application.yml
@@ -29,6 +29,6 @@ management:
 app:
   security:
     jwt:
-      secret: ${JWT_SECRET:super-secret-development-key-that-should-be-rotated}
+      secret: ${JWT_SECRET:?JWT_SECRET environment variable must be provided}
       access-token-ttl-seconds: 900
       refresh-token-ttl-seconds: 604800


### PR DESCRIPTION
## Summary
- require a sufficiently long JWT signing secret via configuration validation and log parsing failures for easier debugging
- tighten chat pagination by validating request limits, capping page sizes, and using stable cursors based on sent timestamp
- clamp recommendation limits, enforce controller parameter validation, and remove unused async configuration

## Testing
- `mvn test` *(fails: repository download blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d243158f948332b111139c5fedbd94